### PR TITLE
DOC: Rephrase hash usage for release commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See [action.yml](./action.yml) for a list of all the available inputs and output
 You can pass inputs like this:
 
 ```yaml
-    - uses: autofix-ci/action@v1  # optionally replace with the latest commit hash
+    - uses: autofix-ci/action@v1  # optionally replace with the commit hash of the latest release
       with:
         fail-fast: false
 ```


### PR DESCRIPTION
I would like to see if it's indeed your recommendation to pin to 551dded8c6cc8a1054039c8bc0b8b48c51dfc6ef as opposed to 2891949f3779a1cafafae1523058501de3d4e944? 

The latter has the advantage of having a clean intention: being explicit and secure about using the latest release; while the former suggest that something critical has been fixed in `main` that has not yet release while in fact it was only minor documentation changes that happened.